### PR TITLE
Create multiple interview slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,18 @@ Invite your users to an interview through an in-app pop-up with this app.
 2. Install the app from the PostHog App Repository
 3. Customize the text and add your booking link e.g. Calendly/Cal.com and enable the plugin
 4. Set the calendar software to redirect to `?bookedUserInterview={feature_flag_name}` after the booking has been completed.
-5. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
+5. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation - {feature_flag_name}` to `is not set` so that it doesn't show to users who have seen the user interview already.
    ![Feature flag user interview not set](feature-flag-config.png)
 
 ## Adding a user interview
 
 1. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
    ![Feature flag user interview not set](feature-flag-config.png)
-2. Add the feature flag to the app config `featureFlagNames` (you can have multiple feature flags by separating them with commas e.g. high_icp,high_value)
+2. Add the feature flag to the app config `featureFlagNames` (you can have multiple feature flags by separating them with commas e.g. interview_high_icp,interview_used_two_feature_flags)
 3. Add the booking links to the app config `bookButtonURLs` (you can have multiple booking links by separating them with commas e.g. https://calendly.com/user1/book,https://calendly.com/user2/15min)
+4. Rollout out the feature flag
+
+The flags won't be shown to users who have seen a popup within the last 90 days (configured with `minDaysSinceLastSeenPopUp`)
 
 ## Demo
 
@@ -24,18 +27,18 @@ Invite your users to an interview through an in-app pop-up with this app.
 
 ## Tracking events
 
-| Event name | Notes |
-| ---------- | ----------- |
-| `User Interview Shown Pop Up` | |
-| `User Interview Dismissed Pop Up` | |
-| `User Interview Clicked Book Button` | |
-| `User Interview Booked` | Requires the redirect after booking to be setup |
+| Event name | Properties | Notes |
+| ---------- | ----------- | ----------- |
+| `User Interview Shown Pop Up` | `{featureFlagName: featureFlagName}` | |
+| `User Interview Dismissed Pop Up` | `{featureFlagName: featureFlagName}` | |
+| `User Interview Clicked Book Button` | `{featureFlagName: featureFlagName}` | |
+| `User Interview Booked` | `{featureFlagName: featureFlagName}` | Requires the redirect after booking to be setup |
 
 ## User properties
 
 | Property name | Notes |
 | ------------- | ----------- |
-| `Seen User Interview Invitation` | Date when the user interview invitation was shown |
+| `Seen User Interview Invitation - featureFlagName}` | Date when the user interview invitation was shown |
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Invite your users to an interview through an in-app pop-up with this app.
 1. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
    ![Feature flag user interview not set](feature-flag-config.png)
 2. Add the feature flag to the app config `featureFlagNames` (you can have multiple feature flags by separating them with commas e.g. interview_high_icp,interview_used_two_feature_flags)
-3. Add the booking links to the app config `bookButtonURLs` (you can have multiple booking links by separating them with commas e.g. https://calendly.com/user1/book,https://calendly.com/user2/15min)
+3. Add the booking links to the app config `bookButtonURLs` (you can have multiple booking links by separating them with commas e.g. https://calendly.com/user1/book,https://calendly.com/user2/15min). The first booking link will correspond to the first feature flags and so on.
 4. Rollout out the feature flag
 
 The flags won't be shown to users who have seen a popup within the last 90 days (configured with `minDaysSinceLastSeenPopUp`)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Invite your users to an interview through an in-app pop-up with this app.
 5. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
    ![Feature flag user interview not set](feature-flag-config.png)
 
+## Adding a user interview
+
+1. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
+   ![Feature flag user interview not set](feature-flag-config.png)
+2. Add the feature flag to the app config `featureFlagNames` (you can have multiple feature flags by separating them with commas e.g. high_icp,high_value)
+3. Add the booking links to the app config `bookButtonURLs` (you can have multiple booking links by separating them with commas e.g. https://calendly.com/user1/book,https://calendly.com/user2/15min)
+
 ## Demo
 
 ![Example popup](example.png)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Invite your users to an interview through an in-app pop-up with this app.
 
 ## Adding a user interview
 
-1. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation` to `is not set` so that it doesn't show to users who have seen the user interview already.
+1. Create a feature flag to control who sees it. And set the filter `Seen User Interview Invitation - {featureFlagName}` to `is not set` so that it doesn't show to users who have seen the user interview already.
    ![Feature flag user interview not set](feature-flag-config.png)
 2. Add the feature flag to the app config `featureFlagNames` (you can have multiple feature flags by separating them with commas e.g. interview_high_icp,interview_used_two_feature_flags)
 3. Add the booking links to the app config `bookButtonURLs` (you can have multiple booking links by separating them with commas e.g. https://calendly.com/user1/book,https://calendly.com/user2/15min). The first booking link will correspond to the first feature flags and so on.

--- a/plugin.json
+++ b/plugin.json
@@ -35,8 +35,8 @@
             "site": true
         },
         {
-            "key": "bookButtonURL",
-            "name": "Book Button URL",
+            "key": "bookButtonURLs",
+            "name": "Book Button URLs",
             "type": "string",
             "default": "https://calendly.com/posthog-luke-harries/user-interview-product-analytics",
             "required": true,
@@ -86,8 +86,8 @@
             "site": true
         },
         {
-            "key": "featureFlagName",
-            "name": "Feature flag name",
+            "key": "featureFlagNames",
+            "name": "Feature flag names",
             "type": "string",
             "default": "user-interview",
             "required": true,
@@ -98,6 +98,14 @@
             "name": "Name of the User Property for seeing a popup",
             "type": "string",
             "default": "Seen User Interview Invitation",
+            "required": true,
+            "site": true
+        },
+        {
+            "key": "minDaysSinceLastSeenPopUp",
+            "name": "Minimum number of days since they've last seen a popup",
+            "type": "number",
+            "default": 90,
             "required": true,
             "site": true
         }

--- a/site.ts
+++ b/site.ts
@@ -234,7 +234,9 @@ export function inject({ config, posthog }) {
             // @ts-ignore
             if (e.target.classList.contains('popup-close-button')) {
                 posthog.capture(config.dismissUserInterviewPopupEvent, {
-                    $set: { [config.userPropertyNameSeenUserInterview]: new Date().toISOString() },
+                    $set: {
+                        [`${config.userPropertyNameSeenUserInterview} - ${featureFlagName}`]: new Date().toISOString(),
+                    },
                     featureFlagName: featureFlagName,
                 })
 
@@ -243,7 +245,9 @@ export function inject({ config, posthog }) {
                 // @ts-ignore
             } else if (e.target.classList.contains('popup-book-button')) {
                 posthog.capture(config.clickBookButtonEvent, {
-                    $set: { [config.userPropertyNameSeenUserInterview]: new Date().toISOString() },
+                    $set: {
+                        [`${config.userPropertyNameSeenUserInterview} - ${featureFlagName}`]: new Date().toISOString(),
+                    },
                     featureFlagName: featureFlagName,
                 })
                 shadow.innerHTML = ''
@@ -266,14 +270,14 @@ export function inject({ config, posthog }) {
         }
     })
 
-    posthog.onFeatureFlags((flags: string[]) => {
+    posthog.onFeatureFlags((flags) => {
         interviewConfigs.forEach((interviewConfig: { featureFlagName: string; bookButtonURL: string }) => {
-            const flagFound = true // flags.includes(interviewConfig.featureFlagName)
-            const notSeenFlagBefore = !localStorage.getItem(
+            const flagFound = flags.includes(config.featureFlagName)
+            const flagNotShownBefore = !localStorage.getItem(
                 getFeatureSessionStorageKey(interviewConfig.featureFlagName)
             )
 
-            if (flagFound && notSeenFlagBefore) {
+            if (flagFound && flagNotShownBefore) {
                 createPopUp(interviewConfig.bookButtonURL, interviewConfig.featureFlagName)
                 return // only show one popup
             }


### PR DESCRIPTION
Adds the ability to have multiple interviews slots with a comma defined list

example config:
```
featureFlagNames: interview_high_icp_general,interview_used_2_feature_flags
bookButtonURLs: https://calendly.com/user1/book,https://calendly.com/user2/15min
```
